### PR TITLE
Update examples (using `map` here is more correct & reusable)

### DIFF
--- a/examples/graph/mistral-to-mistral.ts
+++ b/examples/graph/mistral-to-mistral.ts
@@ -22,13 +22,15 @@ const summary = new Mistral({
 const graph = new Graph().withEdge([
   story,
   summary,
-  (out: Mistral.Output): Mistral.Args => ({
-    input_prompts: [`Summarize the following:\n\n${out.completions[0].text}`],
+  ({ completions }: Mistral.Output): Mistral.Args => ({
+    input_prompts: completions.map(
+      ({ text }) => `Summarize the following:\n\n${text}`,
+    ),
   }),
 ]);
 
 const result = await substrate.compose(graph);
-console.log("STORY:")
+console.log("STORY:");
 console.log(result.data.story.completions[0]?.text);
-console.log("SUMMARY:")
+console.log("SUMMARY:");
 console.log(result.data.summary.completions[0]?.text);

--- a/examples/graph/readme.ts
+++ b/examples/graph/readme.ts
@@ -4,7 +4,7 @@ import { Substrate, Graph, Mistral, Jina } from "substrate";
 
 const SUBSTRATE_API_KEY = process.env["SUBSTRATE_API_KEY"];
 
-//Create a Substrate API client
+// Create a Substrate API client
 const substrate = new Substrate({ apiKey: SUBSTRATE_API_KEY });
 
 const text = "Something you want to summarize...";
@@ -21,7 +21,9 @@ const jina = new Jina({ id: "embedding" }).setOutput();
 const graph = new Graph().withEdge([
   mistral,
   jina,
-  (out: Mistral.Output): Jina.Args => ({ texts: [out.completions[0].text] }),
+  ({ completions }: Mistral.Output): Jina.Args => ({
+    texts: completions.map(({ text }) => text),
+  }),
 ]);
 
 // Run the Graph and see print the result

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -156,7 +156,7 @@ export type ModelNode = z.infer<typeof ModelNodeSchema>;
 
 export const MistralArgsSchema = z
   .object({
-    input_prompts: z.union([z.string(), z.string().array().nonempty()]),
+    input_prompts: z.union([z.string(), z.string().array()]),
     system: z.string().optional(),
     presence_penalty: z.number().optional().default(1.1),
     frequency_penalty: z.number().optional().default(0.0),
@@ -183,7 +183,7 @@ export type Mistral = z.infer<typeof MistralSchema>;
 
 export const JinaArgsSchema = z
   .object({
-    texts: z.string().array().nonempty(),
+    texts: z.string().array(),
     embed_metadata_keys: z.array(z.string()).optional(),
     provider_ids: z.array(z.string()).optional(),
     split: z.boolean().optional(), // false


### PR DESCRIPTION
## Purpose

Some small stylistic/usability changes to the examples and schema. Using a `map` here, while slightly longer I think may be nicer to read and be a bit more reusable.
