### PR TITLE
Adds `visualize` helper

### DIFF
--- a/src/Substrate.ts
+++ b/src/Substrate.ts
@@ -72,6 +72,18 @@ export class Substrate {
     }
   }
 
+  /**
+   *  Visualize the `Graph` on the Substrate website.
+   */
+  visualize(graph: Graph) {
+    const json = JSON.stringify({ dag: graph });
+    const bytes = new TextEncoder().encode(json);
+    const utf16 = String.fromCodePoint(...bytes);
+    const base64 = btoa(utf16);
+
+    return `https://www.substrate.run/visualize/${base64}`;
+  }
+
   requestOptions(body: any) {
     return {
       method: "POST",


### PR DESCRIPTION
## Purpose

Adds a `visualize` helper to build a URL that can be used to visualize a Graph on the Substrate website!

For example,

```
https://www.substrate.run/visualize/eyJkYWciOnsibm9kZXMiOlt7ImlkIjoic3RvcnkiLCJhcmdzIjp7InByb21wdHMiOlt7InByb21wdCI6IldyaXRlIG1lIGEgc3RvcnkgYWJvdXQgdGhhdCB0aW1lIHdlIGhhZCB0byBkZWxpdmVyIHBpenphcyB0byBldmVyeW9uZSBp
biBTcGlyYWwgU3F1YXJlIPCfjZUifV19LCJfc2hvdWxkX291dHB1dF9nbG9iYWxseSI6dHJ1ZSwiY2xhc3MiOiJNaXN0cmFsIiwiZXh0cmFfYXJncyI6eyJtb2RlbCI6Im1pc3RyYWwtN2ItaW5zdHJ1Y3QifX0seyJpZCI6InN1bW1hcnkiLCJhcmdzIjp7Im1heF90b2tlbnMiOjUw
fSwiX3Nob3VsZF9vdXRwdXRfZ2xvYmFsbHkiOnRydWUsImNsYXNzIjoiTWlzdHJhbCIsImV4dHJhX2FyZ3MiOnsibW9kZWwiOiJtaXN0cmFsLTdiLWluc3RydWN0In19XSwiZWRnZXMiOltbInN0b3J5Iiwic3VtbWFyeSIseyJhZGFwdGVyIjp7ImNvZGUiOiIoeyBkYXRhIH0pID0+
ICh7XG4gICAgICAgIHByb21wdHM6IGRhdGEuZmxhdE1hcCgoeyBjb21wbGV0aW9ucyB9KSA9PiBjb21wbGV0aW9ucy5tYXAoKGNvbXBsZXRpb24pID0+ICh7IHByb21wdDogY29tcGxldGlvbiB9KSkpLFxuICAgIH0pIiwicnVudGltZSI6ImRlbm8iLCJydW50aW1lX3ZlcnNpb24i
OiIxLjIuNiJ9fV1dLCJpbml0aWFsX2FyZ3MiOnt9fX0=  
```