### PR TITLE
Use node v18.17.1 for development

### DIFF
--- a/.node-version
+++ b/.node-version
@@ -1,1 +1,1 @@
-lts/hydrogen
+18.17.1

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+18.17.1


### PR DESCRIPTION
The current version of node is set to `lts/hydrogen`, but with the release of `v18.19.x` in that channel an incompatibility has emerged with using `ts-node` (see https://github.com/TypeStrong/ts-node/issues/1997).

It appears `ts-node` relies on an "experimental" feature that was changed in later versions of node and has not yet released a new version to handle it. There are other more elaborate solutions in the linked thread and suggestions for even using an alternative package (eg. https://github.com/privatenumber/tsx). However, I thought the simplest change was to pin to the exact version I had been using for development so far.