### PR TITLE
update base version to 1.0.0

### DIFF
--- a/bin/sync-codegen.ts
+++ b/bin/sync-codegen.ts
@@ -5,7 +5,7 @@ import { readFileSync, writeFileSync } from "fs";
 
 // NOTE: Merged with API version to produce the full SDK version string
 // https://docs.substrate.run/versionin
-const SDK_VERSION = "0.0.1";
+const SDK_VERSION = "1.0.0";
 
 const ok = (message: string) => console.log("\x1b[32m✓\x1b[0m", message);
 const DIR = "../substrate/codegen/typescript";


### PR DESCRIPTION
cc @liamgriffiths – setting the base version to 1.0.0 – saw pypi strip a `02024...` version string and want to make python/typescript consistent 