### PR TITLE
Makefile updates

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -113,11 +113,13 @@ The version of the SDK should be updated in branches being merged into `main` ac
 * MINOR version when you add functionality in a backward compatible manner
 * PATCH version when you make backward compatible bug fixes
 
-### TODO: Allow VERSION Update When Not Updating Generated Files
+### Updating The Package Version
 
-Right now the `VERSION` for the package is managed in `bin/sync-codegen.ts` and running this script will also update the
-package version in `package.json` and the `src/version.ts` file. However if you are only making changes to the SDK code
-and do not want to copy over generated files, then you will have to manually update these three locations for now.
+After making changes, you should:
+* Make sure to bump the `SDK_VERSION` in the `bin/update-version.ts` script
+* Then run `make update-version` to ensure the `package.json` and `src/version.ts` are set correctly.
+
+**NOTE:** The `make update-version` task will run after every `make sync-codegen` too!
 
 ## Releasing
 

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,14 @@ test: ensure
 test-watch: ensure
 	npx vitest
 
+.PHONY: update-version
+update-version: ensure
+	bin/update-version.ts
+
 .PHONY: sync-codegen
 sync-codegen: ensure
 	bin/sync-codegen.ts
+	make update-version
 
 .PHONY: typecheck
 typecheck: ensure

--- a/bin/sync-codegen.ts
+++ b/bin/sync-codegen.ts
@@ -1,11 +1,6 @@
 #!/usr/bin/env -S npx ts-node --transpileOnly
 
 import { execSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "fs";
-
-// NOTE: Merged with API version to produce the full SDK version string
-// https://docs.substrate.run/versioning
-const SDK_VERSION = "1.0.1";
 
 const ok = (message: string) => console.log("\x1b[32m✓\x1b[0m", message);
 const DIR = "../substrate/codegen/typescript";
@@ -14,20 +9,3 @@ execSync(`cp -r ${DIR}/src/* src/`);
 execSync(`cp ../substrate/site/public/openapi.json src/openapi.json`);
 execSync(`cp ${DIR}/GEN_VERSION GEN_VERSION`);
 ok(`Copied generated code from ${DIR}`);
-
-try {
-  const version = readFileSync("GEN_VERSION", "utf-8").split(".")[0];
-  const [major, minor, patch] = SDK_VERSION.split(".");
-  const newVersion = `${major}${version}.${minor}.${patch}`;
-  const packageJsonPath = "package.json";
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-  packageJson.version = newVersion;
-  writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n");
-  ok(`Updated package.json to version ${newVersion}`);
-  const versionTsPath = "src/version.ts";
-  const versionExport = `export const VERSION = "${newVersion}";\n`;
-  writeFileSync(versionTsPath, versionExport);
-  ok(`Updated version.ts to version ${newVersion}`);
-} catch (error) {
-  console.error("Error reading or parsing openapi.json:", error);
-}

--- a/bin/update-version.ts
+++ b/bin/update-version.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env -S npx ts-node --transpileOnly
+
+import { readFileSync, writeFileSync } from "fs";
+
+// NOTE: Merged with API version to produce the full SDK version string
+// https://docs.substrate.run/versioning
+const SDK_VERSION = "1.0.2";
+
+const ok = (message: string) => console.log("\x1b[32m✓\x1b[0m", message);
+
+try {
+  const version = readFileSync("GEN_VERSION", "utf-8").split(".")[0];
+  const [major, minor, patch] = SDK_VERSION.split(".");
+  const newVersion = `${major}${version}.${minor}.${patch}`;
+  const packageJsonPath = "package.json";
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+  packageJson.version = newVersion;
+  writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n");
+  ok(`Updated package.json to version ${newVersion}`);
+  const versionTsPath = "src/version.ts";
+  const versionExport = `export const VERSION = "${newVersion}";\n`;
+  writeFileSync(versionTsPath, versionExport);
+  ok(`Updated version.ts to version ${newVersion}`);
+} catch (error) {
+  console.error("Error reading or parsing openapi.json:", error);
+}
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "substrate",
-  "version": "120240313.0.1",
+  "version": "120240313.0.2",
   "description": "The official SDK for the Substrate API",
   "keywords": [],
   "type": "module",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "120240313.0.1";
+export const VERSION = "120240313.0.2";


### PR DESCRIPTION
When going through the publishing flow a couple of times I wanted to address some of the gotchas and issues I ran into along the way.

* Before publishing the package we're now _always_ going to test + build to ensure that whatever code is in `dist/` wasn't leftover from another branch
* Adds the ability to specify the NPM Distribution Tag using an argument to the task, eg. `make publish NPM_TAG=experimental`
* Adds a confirmation step before following through with publishing the package with the package version + tag printed back
* Splits out the version updating from the `make sync-codegen` script so that you can bump the package version independently of pulling in new generated files: `make update-version` (you must edit the `SDK_VERSION` in `bin/update-version.ts` for now though)