### PR TITLE
Add GitHub Action for Node.js (build + test)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ["18.0.0", "18.17.1", "22.0.0", "24.0.0"]
+        node-version: ["18.17.1"]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
I caught myself merging in a branch that had failed tests and getting some automated test runs in place was something I wanted to do anyway.

This script will attempt to build the SDK and run the tests in all major release versions since Node 17+