### PR TITLE
Add backend constructor option for routing requests

### DIFF
--- a/src/Substrate.ts
+++ b/src/Substrate.ts
@@ -43,7 +43,13 @@ export class Substrate {
   /**
    * Initialize the Substrate SDK.
    */
-  constructor({ apiKey, baseUrl, apiVersion, timeout, backend }: Configuration) {
+  constructor({
+    apiKey,
+    baseUrl,
+    apiVersion,
+    timeout,
+    backend,
+  }: Configuration) {
     if (!apiKey) {
       throw new SubstrateError(
         "An API Key is required. Specify it when constructing the Substrate client: `new Substrate({ apiKey: 'API_KEY' })`",


### PR DESCRIPTION
User can use the `backend` option when constructing the `Substrate` client to control whether requests will be sent to Modal `"v0"` or k8s `"v1"`.

This flag may be removed in the future, but will be used to help cut over Substack a bit more quickly.