### PR TITLE
Add `NodeError` as value to stand-in when Node has bad input or no data

### DIFF
--- a/src/Error.ts
+++ b/src/Error.ts
@@ -4,3 +4,12 @@
 export class SubstrateError extends Error {}
 
 export class RequestTimeoutError extends SubstrateError {}
+
+export class NodeError {
+  type: string;
+  message: string;
+  constructor(type: string, message: string) {
+    this.type = type;
+    this.message = message;
+  }
+}

--- a/src/Mailbox.ts
+++ b/src/Mailbox.ts
@@ -45,7 +45,7 @@ export class Mailbox extends EventTarget {
         const handleRequestCompleted = {
           handleEvent: (e: RequestCompleted) => {
             // When we receive an event, we'll resolve this Promise
-            resolve(e.value.getNodeResponse(node));
+            resolve(e.value.getNodeResult(node));
             // Then we'll remove the event listeners to make sure there these references in the promise go away
             this.removeEventListener(
               RequestCompleted.type,

--- a/src/SubstrateResponse.ts
+++ b/src/SubstrateResponse.ts
@@ -1,4 +1,5 @@
 import { Node } from "substrate/Node";
+import { NodeError } from "substrate/Error";
 
 /**
  * Response to a run request.
@@ -31,7 +32,16 @@ export class SubstrateResponse {
    * Returns a subset of the server response that contains data for
    * a specific `Node`.
    */
-  getNodeResponse(node: Node) {
-    return this.json?.data?.[node.id];
+  getNodeResult(node: Node) {
+    const result = this.json?.data?.[node.id];
+
+    // Errors from the server have these two fields
+    if (result?.type && result?.message) {
+      // NOTE: we only return these errors on client errors.
+      // Server errors are typically 5xx replies.
+      return new NodeError(result.type, result.message);
+    }
+
+    return result || new NodeError("no_data", `Missing data for "${node.id}"`);
   }
 }


### PR DESCRIPTION
We may want to handle some error cases a bit more gracefully, but we'll need to make these changes on the server.

* What does a timeout error look like for a request, per node
* Can we capture internal server errors and return some JSON that describes the problem
