### PR TITLE
Log warning instead of throwing in `Substrate` client constructor w/o API Key

### DIFF
--- a/src/Substrate.ts
+++ b/src/Substrate.ts
@@ -9,7 +9,7 @@ type Configuration = {
   /**
    * [docs/authentication](https://docs.substrate.run/#authentication)
    */
-  apiKey?: string | undefined;
+  apiKey: string | undefined;
 
   /**
    * [docs/versioning](https://docs.substrate.run/versioning)
@@ -33,7 +33,7 @@ type Configuration = {
  * [docs/introduction](https://docs.substrate.run)
  */
 export class Substrate {
-  apiKey: string;
+  apiKey: string | undefined;
   baseUrl: string;
   apiVersion: string;
   timeout: number;
@@ -50,8 +50,8 @@ export class Substrate {
     backend,
   }: Configuration) {
     if (!apiKey) {
-      throw new SubstrateError(
-        "An API Key is required. Specify it when constructing the Substrate client: `new Substrate({ apiKey: 'API_KEY' })`",
+      console.warn(
+        "[Substrate] An API Key is required. Specify it when constructing the client: `new Substrate({ apiKey: 'API_KEY' })`",
       );
     }
     this.apiKey = apiKey;
@@ -83,6 +83,10 @@ export class Substrate {
         for (let node of nodes) node.response = res;
 
         return res;
+      } else {
+        throw new SubstrateError(
+          `Request failed: ${apiResponse.status} ${apiResponse.statusText}`,
+        );
       }
     } catch (err: unknown) {
       if (err instanceof Error) {
@@ -98,8 +102,6 @@ export class Substrate {
     } finally {
       clearTimeout(timeout);
     }
-
-    throw new SubstrateError("Request failed");
   }
 
   /**


### PR DESCRIPTION
Context: https://substratelabs.slack.com/archives/C05V65UTCUB/p1712699871355419

Previously we would throw an error if the user ran the code that would construct the `Substrate` client when they had not set an `apiKey`.

This change is to log a warning instead; though the request will ultimately fail without the API key being set.

This is what it will look like in the log output:
<img width="1056" alt="Screenshot 2024-04-10 at 10 40 36 AM" src="https://github.com/SubstrateLabs/substrate-typescript/assets/179645/94484fda-8244-457e-8b4d-7c6df45a1da5">

The goal is to reduce integration friction with users who may not configure their CI environment in a similar way to production.