### PR TITLE
Allow compose endpoint to be configurable in `runSerialized`

### DIFF
--- a/src/Substrate.ts
+++ b/src/Substrate.ts
@@ -92,8 +92,9 @@ export class Substrate {
   async runSerialized(
     serialized: any,
     nodes: Node[] | null = null,
+    endpoint: string = "/compose",
   ): Promise<SubstrateResponse> {
-    const url = this.baseUrl + "/compose";
+    const url = this.baseUrl + endpoint;
     const req = { dag: serialized };
     // NOTE: we're creating the signal this way instead of AbortController.timeout because it is only very
     // recently available on some environments, so this is a bit more supported.


### PR DESCRIPTION
Adding an additional parameter to `runSerialized` to allow the user to specify the endpoint path where we will run the graph.

In our e2e tests since the endpoint path hosted on Modal does not use `/compose`, we need a way to specify this. 