### PR TITLE
Add pre-commit hook (prettier/formatting)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.1.0"
+    hooks:
+      - id: prettier

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -126,11 +126,21 @@ After making changes, you should:
 
 **NOTE:** The `make update-version` task will run after every `make sync-codegen` too!
 
-## CI
+## CI & Git Hooks
 
 We're using GitHub Actions for running tests, verifying successful builds, typechecking, and formatting (see `.github/workflows/node.js.yml`)
 
 Right now we're running these steps using Node 16 and Node 18, but may add more variants soon. Additionally we may automate the release process through this mechanism as well.
+
+In order to speed up the feedback you can also use the git hooks setup with [`pre-commit`](https://pre-commit.com/).
+
+```sh
+# install pre-commit
+brew install pre-commit
+
+# install git-hooks
+pre-commit install
+```
 
 ## Releasing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/pako": "^2.0.3",
-        "prettier": "^3.1.1",
+        "prettier": "3.1.0",
         "ts-node": "^10.9.2",
         "tsup": "^8.0.1",
         "typescript": "^5.3.3",
@@ -1939,9 +1939,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/pako": "^2.0.3",
-    "prettier": "^3.1.1",
+    "prettier": "3.1.0",
     "ts-node": "^10.9.2",
     "tsup": "^8.0.1",
     "typescript": "^5.3.3",


### PR DESCRIPTION
Sets up `pre-commit` like we have in our main project for `prettier`.

```sh
# install pre-commit
brew install pre-commit

# setup hooks
pre-commit install

# all-set!
```