### PR TITLE
Add request-id header to requests

### DIFF
--- a/bin/update-version.ts
+++ b/bin/update-version.ts
@@ -5,7 +5,7 @@ import { execSync } from "node:child_process";
 
 // NOTE: Merged with API version to produce the full SDK version string
 // https://docs.substrate.run/versioning
-const SDK_VERSION = "1.0.12";
+const SDK_VERSION = "1.0.13";
 
 const ok = (message: string) => console.log("\x1b[32m✓\x1b[0m", message);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "substrate",
-  "version": "120240418.0.12",
+  "version": "120240418.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "substrate",
-      "version": "120240418.0.12",
+      "version": "120240418.0.13",
       "license": "MIT",
       "dependencies": {
         "@types/node-fetch": "^2.6.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "substrate",
-  "version": "120240418.0.12",
+  "version": "120240418.0.13",
   "description": "The official SDK for the Substrate API",
   "repository": {
     "type": "git",

--- a/src/Substrate.ts
+++ b/src/Substrate.ts
@@ -5,6 +5,7 @@ import { SubstrateResponse } from "substrate/SubstrateResponse";
 import { Node } from "substrate/Node";
 import { getPlatformProperties } from "substrate/Platform";
 import { deflate } from "pako";
+import { randomString } from "substrate/idGenerator";
 
 type Configuration = {
   /**
@@ -188,6 +189,7 @@ export class Substrate {
     headers.append("User-Agent", `APIClient/JS ${VERSION}`);
     headers.append("X-Substrate-Version", this.apiVersion);
     headers.append("X-Substrate-Backend", this.backend); // Switch between old and new backends
+    headers.append("X-Substrate-Request-Id", randomString(32));
 
     // Auth
     headers.append("Authorization", `Bearer ${this.apiKey}`);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "120240418.0.12";
+export const VERSION = "120240418.0.13";


### PR DESCRIPTION
Adds a `x-substrate-request-id` header to SDK requests to support request tracing.

Since we already have this `randomString` function here and in the Python SDK I thought I'd go with that for now.

<img width="744" alt="Screenshot 2024-05-17 at 11 00 03 AM" src="https://github.com/SubstrateLabs/substrate-typescript/assets/179645/a9c97fe6-7916-4051-af18-4234d36dbb24">


<img width="758" alt="Screenshot 2024-05-17 at 10 58 41 AM" src="https://github.com/SubstrateLabs/substrate-typescript/assets/179645/bdb5fc4a-8c96-4475-917d-075c8dc64f5a">
