### PR TITLE
Allow `Substrate.run` (and stream) to run nodes dependencies implicitly

### DIFF
--- a/examples/implicit-nodes.ts
+++ b/examples/implicit-nodes.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env -S npx ts-node --transpileOnly
+
+import { Substrate, GenerateText } from "substrate";
+
+async function main() {
+  const SUBSTRATE_API_KEY = process.env["SUBSTRATE_API_KEY"];
+
+  const substrate = new Substrate({ apiKey: SUBSTRATE_API_KEY });
+
+  const a = new GenerateText(
+    { prompt: "tell me about windmills" },
+    { id: "a" },
+  );
+  const b = new GenerateText({ prompt: a.future.text }, { id: "b" });
+  const c = new GenerateText({ prompt: b.future.text }, { id: "c" });
+
+  // Because the `c` is the the final node in the graph we can find nodes it depends
+  // on through the relationships created via the input arguments.
+  const res = await substrate.run(c);
+  console.log(res.json);
+}
+main();

--- a/tests/Node.test.ts
+++ b/tests/Node.test.ts
@@ -20,16 +20,28 @@ describe("Node", () => {
     const n = new FooNode({ prompt: d });
 
     expect(n.toJSON()).toEqual({
-      node: {
-        id: n.id,
-        node: "FooNode",
-        _should_output_globally: true,
-        args: {
-          // @ts-expect-error (accessing protected property)
-          prompt: d.toPlaceholder(),
-        },
+      id: n.id,
+      node: "FooNode",
+      _should_output_globally: true,
+      args: {
+        // @ts-expect-error (accessing protected property)
+        prompt: d.toPlaceholder(),
       },
-      futures: [d.toJSON(), c.toJSON(), a.toJSON(), b.toJSON()],
     });
+  });
+
+  test(".references", () => {
+    const a = new FooNode({ x: "x" });
+    const f1 = a.future.get("x");
+    const f2 = a.future.get("y");
+    const b = new FooNode({ x: f1, z: f2 });
+    const f3 = b.future.get("x");
+    const c = new FooNode({ x: f3 });
+
+    // @ts-ignore (protected)
+    const { nodes, futures } = c.references();
+
+    expect(nodes).toEqual(new Set([a, b, c]));
+    expect(futures).toEqual(new Set([f1, f2, f3]));
   });
 });

--- a/tests/Substrate.test.ts
+++ b/tests/Substrate.test.ts
@@ -8,8 +8,11 @@ class FooNode extends Node {}
 describe("Substrate", () => {
   describe(".serialize", () => {
     test("when there are nodes and futures", () => {
-      const a = new FooNode({ a: 123 });
-      const b = new FooNode({ b: a.future.get("x"), c: sb.concat("x", "y") });
+      const a = new FooNode({ a: 123 }, { id: "a" });
+      const b = new FooNode(
+        { b: a.future.get("x"), c: sb.concat("x", "y") },
+        { id: "b" },
+      );
 
       const result = Substrate.serialize(a, b);
 
@@ -35,6 +38,74 @@ describe("Substrate", () => {
               c: {
                 __$$SB_GRAPH_OP_ID$$__: expect.stringMatching(/future/),
               },
+            },
+            _should_output_globally: true,
+          },
+        ],
+        futures: [
+          {
+            id: expect.stringMatching(/future/),
+            directive: {
+              type: "trace",
+              op_stack: [
+                {
+                  future_id: null,
+                  key: "x",
+                  accessor: "attr",
+                },
+              ],
+              origin_node_id: a.id,
+            },
+          },
+          {
+            id: expect.stringMatching(/future/),
+            directive: {
+              type: "string-concat",
+              items: [
+                {
+                  future_id: null,
+                  val: "x",
+                },
+                {
+                  future_id: null,
+                  val: "y",
+                },
+              ],
+            },
+          },
+        ],
+      });
+    });
+
+    test("when there are nodes and futures, but we only supply the 'final' node", () => {
+      const a = new FooNode({ a: 123 });
+      const b = new FooNode({ b: a.future.get("x"), c: sb.concat("x", "y") });
+
+      // Here we're only supplying `b` and relying on the graph-serialiation to find `a`
+      const result = Substrate.serialize(b);
+
+      expect(result).toEqual({
+        edges: [],
+        initial_args: {},
+        nodes: [
+          {
+            node: "FooNode",
+            id: b.id,
+            args: {
+              b: {
+                __$$SB_GRAPH_OP_ID$$__: expect.stringMatching(/future/),
+              },
+              c: {
+                __$$SB_GRAPH_OP_ID$$__: expect.stringMatching(/future/),
+              },
+            },
+            _should_output_globally: true,
+          },
+          {
+            node: "FooNode",
+            id: a.id,
+            args: {
+              a: 123,
             },
             _should_output_globally: true,
           },


### PR DESCRIPTION

https://github.com/orgs/SubstrateLabs/projects/1/views/3?pane=issue&itemId=66030127

```
  const a = new GenerateText({ prompt: "tell me about windmills" });
  const b = new GenerateText({ prompt: a.future.text });
  const c = new GenerateText({ prompt: b.future.text });

  const res = await substrate.run(c);
```