### PR TITLE
Remove old workaround / fix bug in `sb.interpolate`

### DIFF
--- a/src/Future.ts
+++ b/src/Future.ts
@@ -249,7 +249,6 @@ export class FutureString extends Future<string> {
   ): FutureString {
     return FutureString.concat(
       ...strings
-        .filter((s) => s !== "") // FIXME: Work around until SubstrateLabs/substrate#514 is live
         .flatMap((s: string, i: number) => {
           const expr = exprs[i];
           return expr

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -248,13 +248,12 @@ export class FutureString extends Future<string> {
     ...exprs: ({ toString(): string } | FutureString)[]
   ): FutureString {
     return FutureString.concat(
-      ...strings
-        .flatMap((s: string, i: number) => {
-          const expr = exprs[i];
-          return expr
-            ? [s, expr instanceof Future ? expr : expr.toString()]
-            : [s];
-        }),
+      ...strings.flatMap((s: string, i: number) => {
+        const expr = exprs[i];
+        return expr
+          ? [s, expr instanceof Future ? expr : expr.toString()]
+          : [s];
+      }),
     );
   }
 

--- a/tests/Future.test.ts
+++ b/tests/Future.test.ts
@@ -189,5 +189,21 @@ describe("Future", () => {
       // @ts-expect-error
       expect(i2._result()).resolves.toEqual("~~ texas sun x texas moon ~~");
     });
+
+    test(".interpolate (when there is no space between interpolated items)", async () => {
+      const a = "1";
+      const b = "2";
+      const i1 = FutureString.interpolate`hello${a}${b}`;
+
+      // @ts-expect-error
+      expect(i1._result()).resolves.toEqual("hello12");
+
+      const f1 = FutureString.concat("1");
+      const f2 = FutureString.concat("2");
+      const i2 = FutureString.interpolate`hello${f1}${f2}`;
+
+      // @ts-expect-error
+      expect(i2._result()).resolves.toEqual("hello12");
+    });
   });
 });


### PR DESCRIPTION
Before using `sb.interpolate` when the interpolation items were next to each other a prior workaround was not including them into the `Future` properly.

A simplest example that demonstrates this might be,
```typescript
const a = new Box({ value: sb.interpolate`${"x"}` });
const res = await substrate.run(a);
console.log(JSON.stringify(res.json, null, 2));

// outputs
{
  "data": {
    "node1_S2ZNfqWT": {
      "value": ""
    }
  }
}
```

With this patch these odd cases should work properly.