### PR TITLE
Update package version to `120240617.0.5`

### DIFF
--- a/bin/update-version.ts
+++ b/bin/update-version.ts
@@ -5,7 +5,7 @@ import { execSync } from "node:child_process";
 
 // NOTE: Merged with API version to produce the full SDK version string
 // https://docs.substrate.run/versioning
-const SDK_VERSION = "1.0.4";
+const SDK_VERSION = "1.0.5";
 
 const ok = (message: string) => console.log("\x1b[32m✓\x1b[0m", message);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "substrate",
-  "version": "120240617.0.4",
+  "version": "120240617.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "substrate",
-      "version": "120240617.0.4",
+      "version": "120240617.0.5",
       "license": "MIT",
       "dependencies": {
         "@types/node-fetch": "^2.6.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "substrate",
-  "version": "120240617.0.4",
+  "version": "120240617.0.5",
   "description": "The official SDK for the Substrate API",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "120240617.0.4";
+export const VERSION = "120240617.0.5";


### PR DESCRIPTION
Going to bump the version to include two bug fixes in a new release:
* https://github.com/SubstrateLabs/substrate-typescript/pull/97
* https://github.com/SubstrateLabs/substrate-typescript/pull/98